### PR TITLE
New way to get piece position

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -114,6 +114,16 @@ class Board
 
   private
 
+  def assign_piece_boards
+    squares.each do |row|
+      row.each do |sqr|
+        if sqr.piece
+          sqr.piece.update_board(self)
+        end
+      end
+    end
+  end
+
   def arrange_black_pieces
     squares[1].each do |sqr|
       sqr.piece = Piece.for('p')

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -98,6 +98,7 @@ class Board
   def arrange_pieces
     arrange_black_pieces
     arrange_white_pieces
+    assign_piece_boards
   end
 
   def arrange_pieces_from_fen(full_fen_str)
@@ -110,6 +111,7 @@ class Board
         squares[row_idx][idx].piece = Piece.for(current_fen_char)
       end
     end
+    assign_piece_boards
   end
 
   private

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -176,7 +176,6 @@ class Board
   def update_targ_and_dest(target:, destination:)
     store_selected_square(target)
     store_dest_position(destination)
-    update_current_pc_pos_and_board
     store_pc_moves
   end
 
@@ -226,13 +225,6 @@ class Board
 
   def black_p_in_rank_1?
     squares[7].any? { |sqr| sqr.piece && sqr.piece.letter == 'p' }
-  end
-
-  # update piece position and board
-  def update_current_pc_pos_and_board
-    sqr_pos = @selected_square.position
-    @selected_square.piece.update_position(sqr_pos)
-    @selected_square.piece.update_board(self)
   end
 
   def select_square_from_str(pos_str)

--- a/lib/pawn.rb
+++ b/lib/pawn.rb
@@ -19,6 +19,7 @@ class Pawn < Piece
   end
 
   def valid_moves
+    @position = position
     regular_moves = possible_moves.reject do |position|
       current_sqr = board.square_at_position(position)
       current_sqr.piece

--- a/lib/piece.rb
+++ b/lib/piece.rb
@@ -68,6 +68,7 @@ class Piece
   end
 
   def valid_moves
+    @position = position
     possible_moves.reject do |position|
       current_sqr = board.square_at_position(position)
       if current_sqr.piece

--- a/lib/piece.rb
+++ b/lib/piece.rb
@@ -39,6 +39,16 @@ class Piece
     @board = board
   end
 
+  def position
+    square = nil
+    board.squares.each do |row|
+      row.each do |sqr|
+        square = sqr if sqr.piece && sqr.piece == self
+      end
+    end
+    square.position
+  end
+
   def possible_moves
     moves_array = []
     directions.each do |dir_list|

--- a/spec/bishop_spec.rb
+++ b/spec/bishop_spec.rb
@@ -113,8 +113,6 @@ RSpec.describe Bishop do
       it 'b4 bishop has 3 attack moves' do
         pos = Position.for('b4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
@@ -123,8 +121,6 @@ RSpec.describe Bishop do
       it 'h3 bishop has 1 attack move' do
         pos = Position.for('h3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)
@@ -133,8 +129,6 @@ RSpec.describe Bishop do
       it 'a6 bishop has 1 attack moves' do
         pos = Position.for('a6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)
@@ -143,8 +137,6 @@ RSpec.describe Bishop do
       it 'f8 bishop has 1 attack moves' do
         pos = Position.for('f8')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)

--- a/spec/bishop_spec.rb
+++ b/spec/bishop_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe Bishop do
       it 'c3 bishop has 7 moves' do
         pos = Position.for('c3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)
@@ -25,8 +23,6 @@ RSpec.describe Bishop do
       it 'f1 bishop has 5 moves' do
         pos = Position.for('f1')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 5
         expect(move_count).to eql(exp_count)
@@ -35,8 +31,6 @@ RSpec.describe Bishop do
       it 'h6 bishop has 3 moves' do
         pos = Position.for('h6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
@@ -45,8 +39,6 @@ RSpec.describe Bishop do
       it 'c8 bishop has zero moves' do
         pos = Position.for('c8')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 0
         expect(move_count).to eql(exp_count)
@@ -62,8 +54,6 @@ RSpec.describe Bishop do
       it 'd3 bishop has 9 moves' do
         pos = Position.for('d3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 9
         expect(move_count).to eql(exp_count)
@@ -72,8 +62,6 @@ RSpec.describe Bishop do
       it 'f3 bishop has 8 moves' do
         pos = Position.for('f3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)
@@ -82,8 +70,6 @@ RSpec.describe Bishop do
       it 'd4 bishop has 7 moves' do
         pos = Position.for('d4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)
@@ -92,8 +78,6 @@ RSpec.describe Bishop do
       it 'd6 bishop has 7 moves' do
         pos = Position.for('d6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -78,17 +78,6 @@ RSpec.describe Board do
       expect(inner_dest_pos).to eql(dest_pos)
     end
 
-    it 'updates piece position' do
-      target = 'a2'
-      destination = 'a4'
-      targ_sqr = board.square_at_position(Position.for(target))
-      sqr_pos = targ_sqr.position
-      piece = targ_sqr.piece
-      expect do
-        board.update_targ_and_dest(target: target, destination: destination)
-      end.to change { piece.position }.from(nil).to(sqr_pos)
-    end
-
     it 'saves piece moves to board' do
       target = 'a2'
       destination = 'a4'

--- a/spec/king_spec.rb
+++ b/spec/king_spec.rb
@@ -81,8 +81,6 @@ RSpec.describe King do
       it 'e4 king has 3 attack moves' do
         pos = Position.for('e4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
@@ -91,8 +89,6 @@ RSpec.describe King do
       it 'a5 king has 1 attack move' do
         pos = Position.for('a5')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)

--- a/spec/king_spec.rb
+++ b/spec/king_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe King do
       it 'f4 king has 7 moves' do
         pos = Position.for('f4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)
@@ -25,8 +23,6 @@ RSpec.describe King do
       it 'a6 king has 3 moves' do
         pos = Position.for('a6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
@@ -42,8 +38,6 @@ RSpec.describe King do
       it 'f4 king has 6 moves' do
         pos = Position.for('f4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 6
         expect(move_count).to eql(exp_count)
@@ -52,8 +46,6 @@ RSpec.describe King do
       it 'b5 king has 8 moves' do
         pos = Position.for('b5')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)

--- a/spec/knight_spec.rb
+++ b/spec/knight_spec.rb
@@ -113,8 +113,6 @@ RSpec.describe Knight do
       it 'c6 knight has 3 attack moves' do
         pos = Position.for('c6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
@@ -123,8 +121,6 @@ RSpec.describe Knight do
       it 'c3 knight has 3 attack moves' do
         pos = Position.for('c3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
@@ -133,8 +129,6 @@ RSpec.describe Knight do
       it 'a3 knight has zero attack moves' do
         pos = Position.for('a3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 0
         expect(move_count).to eql(exp_count)
@@ -143,8 +137,6 @@ RSpec.describe Knight do
       it 'b6 knight has 1 attack moves' do
         pos = Position.for('b6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)

--- a/spec/knight_spec.rb
+++ b/spec/knight_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe Knight do
       it 'f3 knight has 5 moves' do
         pos = Position.for('f3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 5
         expect(move_count).to eql(exp_count)
@@ -25,8 +23,6 @@ RSpec.describe Knight do
       it 'b1 knight has 2 moves' do
         pos = Position.for('b1')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -35,8 +31,6 @@ RSpec.describe Knight do
       it 'b8 knight has 2 moves' do
         pos = Position.for('b8')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -45,8 +39,6 @@ RSpec.describe Knight do
       it 'g8 knight has 2 moves' do
         pos = Position.for('g8')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -62,8 +54,6 @@ RSpec.describe Knight do
       it 'c3 knight has 8 moves' do
         pos = Position.for('c3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)
@@ -72,8 +62,6 @@ RSpec.describe Knight do
       it 'b1 knight has 3 moves' do
         pos = Position.for('b1')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
@@ -82,8 +70,6 @@ RSpec.describe Knight do
       it 'b6 knight has 3 moves' do
         pos = Position.for('b6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
@@ -92,8 +78,6 @@ RSpec.describe Knight do
       it 'd6 knight has 8 moves' do
         pos = Position.for('d6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)

--- a/spec/pawn_spec.rb
+++ b/spec/pawn_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe Pawn do
       it 'h2 pawn has 2 moves' do
         pos = Position.for('h2')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -26,8 +24,6 @@ RSpec.describe Pawn do
         pos = Position.for('g3')
         piece = board.square_at_position(pos).piece
         piece.moved
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -36,8 +32,6 @@ RSpec.describe Pawn do
       it 'd2 pawn has 1 moves' do
         pos = Position.for('d2')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)
@@ -47,8 +41,6 @@ RSpec.describe Pawn do
         pos = Position.for('a5')
         piece = board.square_at_position(pos).piece
         piece.moved
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -58,8 +50,6 @@ RSpec.describe Pawn do
         pos = Position.for('c6')
         piece = board.square_at_position(pos).piece
         piece.moved
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 0
         expect(move_count).to eql(exp_count)
@@ -68,8 +58,6 @@ RSpec.describe Pawn do
       it 'f7 pawn has 2 moves' do
         pos = Position.for('f7')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -86,8 +74,6 @@ RSpec.describe Pawn do
         pos = Position.for('b5')
         piece = board.square_at_position(pos).piece
         piece.moved
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -97,8 +83,6 @@ RSpec.describe Pawn do
         pos = Position.for('g3')
         piece = board.square_at_position(pos).piece
         piece.moved
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)

--- a/spec/pawn_spec.rb
+++ b/spec/pawn_spec.rb
@@ -118,8 +118,6 @@ RSpec.describe Pawn do
       it 'b3 bishop has 2 attack moves' do
         pos = Position.for('b3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -128,8 +126,6 @@ RSpec.describe Pawn do
       it 'd4 bishop has 1 attack move' do
         pos = Position.for('d4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)
@@ -138,8 +134,6 @@ RSpec.describe Pawn do
       it 'a7 bishop has 1 attack moves' do
         pos = Position.for('a7')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)
@@ -148,8 +142,6 @@ RSpec.describe Pawn do
       it 'c4 bishop has 1 attack moves' do
         pos = Position.for('c4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)

--- a/spec/queen_spec.rb
+++ b/spec/queen_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe Queen do
       it 'd4 queen has 19 moves' do
         pos = Position.for('d4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 19
         expect(move_count).to eql(exp_count)
@@ -25,8 +23,6 @@ RSpec.describe Queen do
       it 'g6 queen has 16 moves' do
         pos = Position.for('g6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 16
         expect(move_count).to eql(exp_count)
@@ -42,8 +38,6 @@ RSpec.describe Queen do
       it 'd3 queen has 14 moves' do
         pos = Position.for('d3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 14
         expect(move_count).to eql(exp_count)
@@ -52,8 +46,6 @@ RSpec.describe Queen do
       it 'h5 queen has 10 moves' do
         pos = Position.for('h5')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 10
         expect(move_count).to eql(exp_count)

--- a/spec/queen_spec.rb
+++ b/spec/queen_spec.rb
@@ -81,8 +81,6 @@ RSpec.describe Queen do
       it 'd4 queen has 4 attack moves' do
         pos = Position.for('d4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 4
         expect(move_count).to eql(exp_count)
@@ -91,8 +89,6 @@ RSpec.describe Queen do
       it 'g5 queen has 3 attack move' do
         pos = Position.for('g5')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)

--- a/spec/rook_spec.rb
+++ b/spec/rook_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe Rook do
       it 'a1 rook has 4 moves' do
         pos = Position.for('a1')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 4
         expect(move_count).to eql(exp_count)
@@ -25,8 +23,6 @@ RSpec.describe Rook do
       it 'e4 rook has 10 moves' do
         pos = Position.for('e4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 10
         expect(move_count).to eql(exp_count)
@@ -35,8 +31,6 @@ RSpec.describe Rook do
       it 'h5 rook has 10 moves' do
         pos = Position.for('h5')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 10
         expect(move_count).to eql(exp_count)
@@ -45,8 +39,6 @@ RSpec.describe Rook do
       it 'a8 rook has zero moves' do
         pos = Position.for('a8')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 0
         expect(move_count).to eql(exp_count)
@@ -62,8 +54,6 @@ RSpec.describe Rook do
       it 'b3 rook has 5 moves' do
         pos = Position.for('b3')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 5
         expect(move_count).to eql(exp_count)
@@ -72,8 +62,6 @@ RSpec.describe Rook do
       it 'e4 rook has 8 moves' do
         pos = Position.for('e4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)
@@ -82,8 +70,6 @@ RSpec.describe Rook do
       it 'f5 rook has 6 moves' do
         pos = Position.for('f5')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 6
         expect(move_count).to eql(exp_count)
@@ -92,8 +78,6 @@ RSpec.describe Rook do
       it 'a6 rook has 8 moves' do
         pos = Position.for('a6')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.valid_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)

--- a/spec/rook_spec.rb
+++ b/spec/rook_spec.rb
@@ -113,8 +113,6 @@ RSpec.describe Rook do
       it 'b4 rook has 2 attack moves' do
         pos = Position.for('b4')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
@@ -123,8 +121,6 @@ RSpec.describe Rook do
       it 'h1 rook has 1 attack move' do
         pos = Position.for('h1')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)
@@ -133,8 +129,6 @@ RSpec.describe Rook do
       it 'h5 rook has 3 attack moves' do
         pos = Position.for('h5')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
@@ -143,8 +137,6 @@ RSpec.describe Rook do
       it 'a8 rook has zero attack moves' do
         pos = Position.for('a8')
         piece = board.square_at_position(pos).piece
-        piece.update_position(pos)
-        piece.update_board(board)
         move_count = piece.attack_moves.length
         exp_count = 0
         expect(move_count).to eql(exp_count)


### PR DESCRIPTION
Board will no longer have to constantly update piece position and board attribute before each move. Piece's will now be assigned the same instance of board during their initial arrangment and with that, they will calculate their own positions whenever it's needed. This should make checking for check a lot more straightfoward. I had to update many of the tests to no longer externally update the pieces. So I can confirm that nothing is broken.