### PR TITLE
Legal moves

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -279,7 +279,7 @@ class Board
 
   def store_pc_moves
     pc = @selected_square.piece
-    @sel_pc_moves = pc.valid_moves
+    @sel_pc_moves = pc.legal_moves
   end
 end
 

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -179,12 +179,12 @@ class Board
     store_pc_moves
   end
 
-  def is_move_valid?
+  def is_move_legal?
     @sel_pc_moves.include?(@destination_position)
   end
 
   def place_piece
-    return unless is_move_valid?
+    return unless is_move_legal?
 
     current_pc = @selected_square.piece
     dest_square = square_at_position(@destination_position)

--- a/lib/pawn.rb
+++ b/lib/pawn.rb
@@ -18,7 +18,7 @@ class Pawn < Piece
     letter == 'p'
   end
 
-  def valid_moves
+  def pseudolegal_moves
     @position = position
     regular_moves = possible_moves.reject do |position|
       current_sqr = board.square_at_position(position)

--- a/lib/piece.rb
+++ b/lib/piece.rb
@@ -92,6 +92,18 @@ class Piece
     end
   end
 
+  def legal_moves
+    valid_moves.reject do |pos|
+      dup_brd = board_copy
+      sqr = dup_brd.square_at_position(position)
+      dup_brd.instance_variable_set(:@selected_square, sqr)
+      dup_brd.instance_variable_set(:@destination_position, pos)
+      dup_brd.instance_variable_set(:@sel_pc_moves, [pos])
+      dup_brd.place_piece
+      dup_brd.king_in_check? && dup_brd.checked_king.color == color
+    end
+  end
+
   def self.for(letter)
     registry.find do |candidate|
       candidate.handles?(letter.downcase)
@@ -116,17 +128,6 @@ class Piece
     possible_moves.reject do |position|
       current_sqr = board.square_at_position(position)
       current_sqr.piece && current_sqr.piece.color == color
-    end
-  end
-
-  def legal_moves(moves)
-    moves.reject do |pos|
-      dup_brd = board_copy
-      dup_brd.instance_variable_set(:@selected_square, square)
-      dup_brd.instance_variable_set(:@destination_position, pos)
-      dup_brd.instance_variable_set(:@sel_pc_moves, [pos])
-      dup_brd.place_piece
-      true if dup_brd.king_in_check? && dup_brd.checked_king.color == color
     end
   end
 

--- a/lib/piece.rb
+++ b/lib/piece.rb
@@ -67,7 +67,7 @@ class Piece
     end
   end
 
-  def valid_moves
+  def pseudolegal_moves
     @position = position
     moves_without_own_piece
   end
@@ -86,14 +86,14 @@ class Piece
   end
 
   def attack_moves
-    valid_moves.select do |pos|
+    pseudolegal_moves.select do |pos|
       current_sqr = board.square_at_position(pos)
       current_sqr.piece
     end
   end
 
   def legal_moves
-    valid_moves.reject do |pos|
+    pseudolegal_moves.reject do |pos|
       dup_brd = board_copy
       sqr = dup_brd.square_at_position(position)
       dup_brd.instance_variable_set(:@selected_square, sqr)

--- a/spec/bishop_spec.rb
+++ b/spec/bishop_spec.rb
@@ -143,5 +143,22 @@ RSpec.describe Bishop do
       end
     end
   end
+
+  describe '#legal_moves' do
+    context 'for fen string 1' do
+      before do
+        fen_str1 = '3k4/3b4/8/8/R3n3/8/3R4/8 w - - 0 1'
+        board.arrange_pieces_from_fen(fen_str1)
+      end
+
+      it 'd7 bishop has zero moves' do
+        pos = Position.for('d7')
+        piece = board.square_at_position(pos).piece
+        move_count = piece.legal_moves.length
+        exp_count = 0
+        expect(move_count).to eql(exp_count)
+      end
+    end
+  end
 end
 

--- a/spec/bishop_spec.rb
+++ b/spec/bishop_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/rook'
 RSpec.describe Bishop do
   let(:board) { Board.new }
 
-  describe '#valid_moves' do
+  describe '#pseudolegal_moves' do
     context 'for fen string 1' do
       before do
         fen_str1 = 'rnbqk1nr/pppppp1p/7b/8/5p2/2B1P3/PPPP1PPP/RN1QKBNR w KQkq - 0 1'
@@ -15,7 +15,7 @@ RSpec.describe Bishop do
       it 'c3 bishop has 7 moves' do
         pos = Position.for('c3')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)
       end
@@ -23,7 +23,7 @@ RSpec.describe Bishop do
       it 'f1 bishop has 5 moves' do
         pos = Position.for('f1')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 5
         expect(move_count).to eql(exp_count)
       end
@@ -31,7 +31,7 @@ RSpec.describe Bishop do
       it 'h6 bishop has 3 moves' do
         pos = Position.for('h6')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
       end
@@ -39,7 +39,7 @@ RSpec.describe Bishop do
       it 'c8 bishop has zero moves' do
         pos = Position.for('c8')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 0
         expect(move_count).to eql(exp_count)
       end
@@ -54,7 +54,7 @@ RSpec.describe Bishop do
       it 'd3 bishop has 9 moves' do
         pos = Position.for('d3')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 9
         expect(move_count).to eql(exp_count)
       end
@@ -62,7 +62,7 @@ RSpec.describe Bishop do
       it 'f3 bishop has 8 moves' do
         pos = Position.for('f3')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)
       end
@@ -70,7 +70,7 @@ RSpec.describe Bishop do
       it 'd4 bishop has 7 moves' do
         pos = Position.for('d4')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)
       end
@@ -78,7 +78,7 @@ RSpec.describe Bishop do
       it 'd6 bishop has 7 moves' do
         pos = Position.for('d6')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)
       end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/board'
 RSpec.describe Board do
   subject(:board) { described_class.new }
 
-  describe '#is_move_valid?' do
+  describe '#is_move_legal?' do
     context "when destination is not among piece's moves" do
       before do
         board.arrange_pieces
@@ -16,7 +16,7 @@ RSpec.describe Board do
       end
 
       it 'returns false' do
-        result = board.is_move_valid?
+        result = board.is_move_legal?
         expect(result).to be false
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe Board do
       end
 
       it 'returns true' do
-        result = board.is_move_valid?
+        result = board.is_move_legal?
         expect(result).to be true
       end
     end

--- a/spec/king_spec.rb
+++ b/spec/king_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/king'
 RSpec.describe King do
   let(:board) { Board.new }
 
-  describe '#valid_moves' do
+  describe '#pseudolegal_moves' do
     context 'for fen string 1' do
       before do
         fen_str1 = 'rnbq1bnr/pppppppp/k7/8/5K2/6P1/PPPPPP1P/RNBQ1BNR w HAha - 0 1'
@@ -15,7 +15,7 @@ RSpec.describe King do
       it 'f4 king has 7 moves' do
         pos = Position.for('f4')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)
       end
@@ -23,7 +23,7 @@ RSpec.describe King do
       it 'a6 king has 3 moves' do
         pos = Position.for('a6')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
       end
@@ -38,7 +38,7 @@ RSpec.describe King do
       it 'f4 king has 6 moves' do
         pos = Position.for('f4')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 6
         expect(move_count).to eql(exp_count)
       end
@@ -46,7 +46,7 @@ RSpec.describe King do
       it 'b5 king has 8 moves' do
         pos = Position.for('b5')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)
       end

--- a/spec/king_spec.rb
+++ b/spec/king_spec.rb
@@ -95,5 +95,22 @@ RSpec.describe King do
       end
     end
   end
+
+  describe '#legal_moves' do
+    context 'for fen string 1' do
+      before do
+        fen_str1 = 'k7/8/8/6K1/8/8/5Q2/1R6 w - - 0 1'
+        board.arrange_pieces_from_fen(fen_str1)
+      end
+
+      it 'a8 king has zero moves' do
+        pos = Position.for('a8')
+        piece = board.square_at_position(pos).piece
+        move_count = piece.legal_moves.length
+        exp_count = 0
+        expect(move_count).to eql(exp_count)
+      end
+    end
+  end
 end
 

--- a/spec/knight_spec.rb
+++ b/spec/knight_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/knight'
 RSpec.describe Knight do
   let(:board) { Board.new }
 
-  describe '#valid_moves' do
+  describe '#pseudolegal_moves' do
     context 'for fen string 1' do
       before do
         fen_str1 = 'rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R w KQkq - 0 1'
@@ -15,7 +15,7 @@ RSpec.describe Knight do
       it 'f3 knight has 5 moves' do
         pos = Position.for('f3')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 5
         expect(move_count).to eql(exp_count)
       end
@@ -23,7 +23,7 @@ RSpec.describe Knight do
       it 'b1 knight has 2 moves' do
         pos = Position.for('b1')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
       end
@@ -31,7 +31,7 @@ RSpec.describe Knight do
       it 'b8 knight has 2 moves' do
         pos = Position.for('b8')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
       end
@@ -39,7 +39,7 @@ RSpec.describe Knight do
       it 'g8 knight has 2 moves' do
         pos = Position.for('g8')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
       end
@@ -54,7 +54,7 @@ RSpec.describe Knight do
       it 'c3 knight has 8 moves' do
         pos = Position.for('c3')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)
       end
@@ -62,7 +62,7 @@ RSpec.describe Knight do
       it 'b1 knight has 3 moves' do
         pos = Position.for('b1')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
       end
@@ -70,7 +70,7 @@ RSpec.describe Knight do
       it 'b6 knight has 3 moves' do
         pos = Position.for('b6')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 3
         expect(move_count).to eql(exp_count)
       end
@@ -78,7 +78,7 @@ RSpec.describe Knight do
       it 'd6 knight has 8 moves' do
         pos = Position.for('d6')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 7
         expect(move_count).to eql(exp_count)
       end

--- a/spec/knight_spec.rb
+++ b/spec/knight_spec.rb
@@ -143,5 +143,22 @@ RSpec.describe Knight do
       end
     end
   end
+
+  describe '#legal_moves' do
+    context 'for fen string 1' do
+      before do
+        fen_str1 = '3k4/8/3R4/8/4n3/8/8/8 w - - 0 1'
+        board.arrange_pieces_from_fen(fen_str1)
+      end
+
+      it 'e4 knight has 1 moves' do
+        pos = Position.for('e4')
+        piece = board.square_at_position(pos).piece
+        move_count = piece.legal_moves.length
+        exp_count = 1
+        expect(move_count).to eql(exp_count)
+      end
+    end
+  end
 end
 

--- a/spec/pawn_spec.rb
+++ b/spec/pawn_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/pawn'
 RSpec.describe Pawn do
   let(:board) { Board.new }
 
-  describe '#valid_moves' do
+  describe '#pseudolegal_moves' do
     context 'for fen string 1' do
       before do
         fen_str1 = 'rnbqkb1r/1p2pppp/2p5/p1R5/1N1p1n2/6P1/PPPPPP1P/1NBQKB1R w Kkq - 0 1'
@@ -15,7 +15,7 @@ RSpec.describe Pawn do
       it 'h2 pawn has 2 moves' do
         pos = Position.for('h2')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
       end
@@ -24,7 +24,7 @@ RSpec.describe Pawn do
         pos = Position.for('g3')
         piece = board.square_at_position(pos).piece
         piece.moved
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
       end
@@ -32,7 +32,7 @@ RSpec.describe Pawn do
       it 'd2 pawn has 1 moves' do
         pos = Position.for('d2')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 1
         expect(move_count).to eql(exp_count)
       end
@@ -41,7 +41,7 @@ RSpec.describe Pawn do
         pos = Position.for('a5')
         piece = board.square_at_position(pos).piece
         piece.moved
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
       end
@@ -50,7 +50,7 @@ RSpec.describe Pawn do
         pos = Position.for('c6')
         piece = board.square_at_position(pos).piece
         piece.moved
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 0
         expect(move_count).to eql(exp_count)
       end
@@ -58,7 +58,7 @@ RSpec.describe Pawn do
       it 'f7 pawn has 2 moves' do
         pos = Position.for('f7')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
       end
@@ -74,7 +74,7 @@ RSpec.describe Pawn do
         pos = Position.for('b5')
         piece = board.square_at_position(pos).piece
         piece.moved
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
       end
@@ -83,7 +83,7 @@ RSpec.describe Pawn do
         pos = Position.for('g3')
         piece = board.square_at_position(pos).piece
         piece.moved
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 2
         expect(move_count).to eql(exp_count)
       end

--- a/spec/pawn_spec.rb
+++ b/spec/pawn_spec.rb
@@ -148,5 +148,22 @@ RSpec.describe Pawn do
       end
     end
   end
+
+  describe '#legal_moves' do
+    context 'for fen string 1' do
+      before do
+        fen_str1 = '8/3q4/4k3/8/2P3P1/7B/8/3K4 w - - 0 1'
+        board.arrange_pieces_from_fen(fen_str1)
+      end
+
+      it 'c4 pawn has zero moves' do
+        pos = Position.for('c4')
+        piece = board.square_at_position(pos).piece
+        move_count = piece.legal_moves.length
+        exp_count = 0
+        expect(move_count).to eql(exp_count)
+      end
+    end
+  end
 end
 

--- a/spec/pawn_spec.rb
+++ b/spec/pawn_spec.rb
@@ -172,6 +172,22 @@ RSpec.describe Pawn do
         expect(move_count).to eql(exp_count)
       end
     end
+
+    context 'for fen string 1' do
+      before do
+        fen_str1 = '8/3q4/8/4k3/3P2P1/7B/8/3K4 w - - 0 1'
+        board.arrange_pieces_from_fen(fen_str1)
+      end
+
+      it '(already moved) d4 pawn has 1 moves' do
+        pos = Position.for('d4')
+        piece = board.square_at_position(pos).piece
+        piece.moved
+        move_count = piece.legal_moves.length
+        exp_count = 1
+        expect(move_count).to eql(exp_count)
+      end
+    end
   end
 end
 

--- a/spec/pawn_spec.rb
+++ b/spec/pawn_spec.rb
@@ -163,6 +163,14 @@ RSpec.describe Pawn do
         exp_count = 0
         expect(move_count).to eql(exp_count)
       end
+
+      it 'g4 pawn has zero moves' do
+        pos = Position.for('g4')
+        piece = board.square_at_position(pos).piece
+        move_count = piece.legal_moves.length
+        exp_count = 0
+        expect(move_count).to eql(exp_count)
+      end
     end
   end
 end

--- a/spec/pawn_spec.rb
+++ b/spec/pawn_spec.rb
@@ -187,6 +187,15 @@ RSpec.describe Pawn do
         exp_count = 1
         expect(move_count).to eql(exp_count)
       end
+
+      it '(already moved) g4 pawn has 1 moves' do
+        pos = Position.for('g4')
+        piece = board.square_at_position(pos).piece
+        piece.moved
+        move_count = piece.legal_moves.length
+        exp_count = 1
+        expect(move_count).to eql(exp_count)
+      end
     end
   end
 end

--- a/spec/queen_spec.rb
+++ b/spec/queen_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/queen'
 RSpec.describe Queen do
   let(:board) { Board.new }
 
-  describe '#valid_moves' do
+  describe '#pseudolegal_moves' do
     context 'for fen string 1' do
       before do
         fen_str1 = 'rnb1kbnr/pppppppp/6q1/8/3Q4/8/PPPPPPPP/RNB1KBNR w KQkq - 0 1'
@@ -15,7 +15,7 @@ RSpec.describe Queen do
       it 'd4 queen has 19 moves' do
         pos = Position.for('d4')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 19
         expect(move_count).to eql(exp_count)
       end
@@ -23,7 +23,7 @@ RSpec.describe Queen do
       it 'g6 queen has 16 moves' do
         pos = Position.for('g6')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 16
         expect(move_count).to eql(exp_count)
       end
@@ -38,7 +38,7 @@ RSpec.describe Queen do
       it 'd3 queen has 14 moves' do
         pos = Position.for('d3')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 14
         expect(move_count).to eql(exp_count)
       end
@@ -46,7 +46,7 @@ RSpec.describe Queen do
       it 'h5 queen has 10 moves' do
         pos = Position.for('h5')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 10
         expect(move_count).to eql(exp_count)
       end

--- a/spec/queen_spec.rb
+++ b/spec/queen_spec.rb
@@ -95,5 +95,22 @@ RSpec.describe Queen do
       end
     end
   end
+
+  describe '#legal_moves' do
+    context 'for fen string 1' do
+      before do
+        fen_str1 = '8/8/8/8/4Q3/2n5/8/1K6 w - - 0 1'
+        board.arrange_pieces_from_fen(fen_str1)
+      end
+
+      it 'e4 queen has zero moves' do
+        pos = Position.for('e4')
+        piece = board.square_at_position(pos).piece
+        move_count = piece.legal_moves.length
+        exp_count = 0
+        expect(move_count).to eql(exp_count)
+      end
+    end
+  end
 end
 

--- a/spec/rook_spec.rb
+++ b/spec/rook_spec.rb
@@ -159,6 +159,21 @@ RSpec.describe Rook do
         expect(move_count).to eql(exp_count)
       end
     end
+
+    context 'for fen string 2' do
+      before do
+        fen_str2 = '2k5/8/8/Q2r4/6B1/8/8/8 w - - 0 1'
+        board.arrange_pieces_from_fen(fen_str2)
+      end
+
+      it 'd5 rook has 2 moves' do
+        pos = Position.for('d5')
+        piece = board.square_at_position(pos).piece
+        move_count = piece.legal_moves.length
+        exp_count = 2
+        expect(move_count).to eql(exp_count)
+      end
+    end
   end
 end
 

--- a/spec/rook_spec.rb
+++ b/spec/rook_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/rook'
 RSpec.describe Rook do
   let(:board) { Board.new }
 
-  describe '#valid_moves' do
+  describe '#pseudolegal_moves' do
     context 'for fen string 1' do
       before do
         fen_str1 = 'rnbqkb2/pppppppp/7n/7r/P3R3/2NB4/1PPPPPPP/R2QKBN1 w Qq - 0 1'
@@ -15,7 +15,7 @@ RSpec.describe Rook do
       it 'a1 rook has 4 moves' do
         pos = Position.for('a1')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 4
         expect(move_count).to eql(exp_count)
       end
@@ -23,7 +23,7 @@ RSpec.describe Rook do
       it 'e4 rook has 10 moves' do
         pos = Position.for('e4')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 10
         expect(move_count).to eql(exp_count)
       end
@@ -31,7 +31,7 @@ RSpec.describe Rook do
       it 'h5 rook has 10 moves' do
         pos = Position.for('h5')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 10
         expect(move_count).to eql(exp_count)
       end
@@ -39,7 +39,7 @@ RSpec.describe Rook do
       it 'a8 rook has zero moves' do
         pos = Position.for('a8')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 0
         expect(move_count).to eql(exp_count)
       end
@@ -54,7 +54,7 @@ RSpec.describe Rook do
       it 'b3 rook has 5 moves' do
         pos = Position.for('b3')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 5
         expect(move_count).to eql(exp_count)
       end
@@ -62,7 +62,7 @@ RSpec.describe Rook do
       it 'e4 rook has 8 moves' do
         pos = Position.for('e4')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)
       end
@@ -70,7 +70,7 @@ RSpec.describe Rook do
       it 'f5 rook has 6 moves' do
         pos = Position.for('f5')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 6
         expect(move_count).to eql(exp_count)
       end
@@ -78,7 +78,7 @@ RSpec.describe Rook do
       it 'a6 rook has 8 moves' do
         pos = Position.for('a6')
         piece = board.square_at_position(pos).piece
-        move_count = piece.valid_moves.length
+        move_count = piece.pseudolegal_moves.length
         exp_count = 8
         expect(move_count).to eql(exp_count)
       end

--- a/spec/rook_spec.rb
+++ b/spec/rook_spec.rb
@@ -143,5 +143,22 @@ RSpec.describe Rook do
       end
     end
   end
+
+  describe '#legal_moves' do
+    context 'for fen string 1' do
+      before do
+        fen_str1 = '2k5/3r4/Q7/5B2/8/8/8/8 w - - 0 1'
+        board.arrange_pieces_from_fen(fen_str1)
+      end
+
+      it 'd7 rook has zero moves' do
+        pos = Position.for('d7')
+        piece = board.square_at_position(pos).piece
+        move_count = piece.legal_moves.length
+        exp_count = 0
+        expect(move_count).to eql(exp_count)
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
The board will now use the final form of piece move validation. With these changes, players will be unable to make moves that place/leave their king in check. This is the foundation upon which checkmate and stalemate will be implemented. There will also be a method name change. `#valid_moves` will now be `#pseudolegal_moves`. This should make it easier to distinguish it from `#legal_moves`.